### PR TITLE
完善 Windows 上的三个搜索框样式及文字颜色

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -33,6 +33,11 @@
   margin-top: 0.66em;
 }
 
+/*** Search settings ***/
+.list-group-header > div{
+  padding-top: 10px;
+}
+
 /****** #write basic ******/
 #write {
     position: static;

--- a/blubook.css
+++ b/blubook.css
@@ -11,10 +11,26 @@
     --active-file-border-color: #757575;
     --active-search-item-bg-color: #23242b;
     --item-hover-bg-color: #ececec;
-    --item-hover-text-color: #f5f7f9;
+    --item-hover-text-color: #000000;
     --control-text-color: #ddd;
     --window-border: 1px solid #183055;
     --code-cursor: #f0f0f0;
+}
+
+/*** Search file or outline ***/
+#file-library-search-panel{
+  padding-top: 16px;
+} 
+
+#filesearch-case-option-btn,
+#filesearch-word-option-btn{
+  margin-top: 8px;
+  background: var(--side-bar-bg-color);
+}
+
+/*** Search words ***/
+#search-panel-input{
+  margin-top: 0.66em;
 }
 
 /****** #write basic ******/


### PR DESCRIPTION
尝试完善：

文件/大纲搜索框上部被遮住及右侧按钮偏移的问题（#24）：

<details>
  			<summary><strong>Screenshoots</strong></summary>
 
![image](https://user-images.githubusercontent.com/51501079/100544338-ee05c600-328f-11eb-875f-0b01000d3192.png)

![image](https://user-images.githubusercontent.com/61276495/99235425-c8f56a00-2830-11eb-91e2-ca105c829e0c.png)

  </details>

字符搜索框、设置搜索框偏上的现象：

<details>
  			<summary><strong>Screenshoots</strong></summary>

![image](https://user-images.githubusercontent.com/51501079/100544364-15f52980-3290-11eb-9ec6-efae5b380e2d.png)

![image](https://user-images.githubusercontent.com/61276495/98926061-ca155700-2511-11eb-988c-5ad3c8d02911.png)

  </details>

退出、右键面板 hover 时文字颜色为浅色，与背景色相近不易辨识的问题：

<details>
  			<summary><strong>Screenshoots</strong></summary>

![image](https://user-images.githubusercontent.com/51501079/100544374-32916180-3290-11eb-81fd-3b90056349ca.png)
  
![image](https://user-images.githubusercontent.com/51501079/100544382-3a510600-3290-11eb-95d6-29bf12ba5fdd.png)


  </details>