### PR TITLE
完善设置页 input 元素样式

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -17,25 +17,10 @@
     --code-cursor: #f0f0f0;
 }
 
-/*** Search file or outline ***/
-#file-library-search-panel{
-  padding-top: 16px;
-} 
-
+/*** Btn in search bar ***/
 #filesearch-case-option-btn,
 #filesearch-word-option-btn{
-  margin-top: 8px;
   background: var(--side-bar-bg-color);
-}
-
-/*** Search words ***/
-#search-panel-input{
-  margin-top: 0.66em;
-}
-
-/*** Search settings ***/
-.list-group-header > div{
-  padding-top: 10px;
 }
 
 /****** #write basic ******/
@@ -790,12 +775,15 @@ div.md-mathjax-preview.mathjax-candidate.mathjax-candidate-show {
   background-color: white;
 }
 
-input {
+input{
   font-weight: bold;
   background-color: inherit;
   background-color: var(--bg-color);
   color: var(--text-color)!important;
-  transform: translateY(-8px);
+}
+
+#write input {
+  transform: translateY(-6.5px);
 }
 
 .task-list{
@@ -878,5 +866,4 @@ input {
 .md-fences .code-tooltip {
   background-color: #263238;
 }
-
 


### PR DESCRIPTION
尝试解决设置页选中框及个别输入框发生偏移的问题：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/100591802-3a551280-3331-11eb-83d4-b85d94602472.png)

</details>

期间发现原代码中似乎是为了完善编辑页面中的选中框样式：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/100591955-725c5580-3331-11eb-8f04-361360024293.png)


</details>

而添加了这样一段代码：

```CSS
input{
  ...
  transform: translateY(-7px);
}
```

这段代码全局影响了 `input` 元素，包括设置页面中的选中框及[ Issues \#24 ](https://github.com/FishionYu/typora-blubook-theme/issues/24)和[ Pull Request \#29 ](https://github.com/FishionYu/typora-blubook-theme/pull/29)中提到的查找框。

所以这次 PR 将 `transform: translateY(-7px);` 的影响限制在了编辑面板中（顺便将 `-7px` 改为 `-6.5px`，似乎修改后选中框要更加整齐）：

```CSS
#write input {
  transform: translateY(-6.5px);
}
```

相应地，删除了[ Pull Request \#29 ](https://github.com/FishionYu/typora-blubook-theme/pull/29)中加入的现已不再需要的代码。