### PR TITLE
完善代码中字体、背景色、解决偏移

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -873,9 +873,7 @@ code {
 
 /******Code background******/
 code:not(.md-search-expand) {
-    /* rgb(233, 240, 254) */
-    /* rgb(245, 247, 249) */
-    background: hsl(208, 84%, 88%) !important;
+    background: rgb(239, 243, 247) !important;
 }
 
 /******Color when select to search******/
@@ -887,7 +885,7 @@ code,
 pre {
   font-size: 95% !important;
   font-weight: normal;
-  font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
+  font-family: 'Cascadia Code', Consolas, 'Glow Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
   -webkit-font-smoothing: initial;
   -moz-osx-font-smoothing: initial
 }
@@ -1134,7 +1132,7 @@ input {
 }
 
 .md-fences .code-tooltip {
-    background-color: rgb(53, 95, 127);
+    background-color:  #263238;
 }
 
 #write .cm-s-inner .CodeMirror-selected,

--- a/blubook.css
+++ b/blubook.css
@@ -15,6 +15,8 @@
   --control-text-color: #ddd;
   --window-border: 1px solid #183055;
   --code-cursor: #f0f0f0;
+  --search-select-bg-color: rgba(248, 192, 116, .3);
+  --search-select-text-color: rgb(59, 69, 78);
 }
 
 /*** Btn in search bar ***/
@@ -214,7 +216,7 @@ ul>li>ul>li>ul>li {
 }
 
 ol,
-ul {
+ul:not(#sidebar-files-menu,#context-menu) {
   padding-left: 2rem;
   line-height: 1;
 }
@@ -611,7 +613,7 @@ tt {
 }
 
 #typora-sidebar #outline-content .outline-item:hover {
-  background: #202020;
+	background: var(--active-file-bg-color);
 }
 
 #typora-sidebar #ty-sidebar-footer #sidebar-files-menu .show+.menuitem-group-label.show {
@@ -862,23 +864,30 @@ pre.CodeMirror-line {
 
 /****** Code style ******/
 code {
-  font-size: .9rem;
-  /*   color: #333333; /*  #537AA2;  
-      border: 1px solid #d0d0d0;  */
-  font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', monospace;
   padding: .2rem .2rem;
   border-radius: 3px;
-  background: #f5f7f9 !important;
   display: inline;
   vertical-align: bottom;
   line-height: 1.8;
+}
+
+/******Code background******/
+code:not(.md-search-expand) {
+    /* rgb(233, 240, 254) */
+    /* rgb(245, 247, 249) */
+    background: hsl(208, 84%, 88%) !important;
+}
+
+/******Color when select to search******/
+.md-search-expand code {
+    background: hsla(0, 0%, 0%, 0) !important;
 }
 
 code,
 pre {
   font-size: 95% !important;
   font-weight: normal;
-  font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', monospace;
+  font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
   -webkit-font-smoothing: initial;
   -moz-osx-font-smoothing: initial
 }
@@ -950,8 +959,16 @@ input {
   color: var(--text-color) !important;
 }
 
-#write input {
+#write input:not(#md-grid-width):not(#md-grid-height) {
   transform: translateY(-6.5px);
+}
+
+#write .popover.bottom.md-table-resize-popover{
+    width: 140px;
+}
+
+#write .md-grid-board-wrap input {
+    text-align: center !important;
 }
 
 .task-list {
@@ -1117,5 +1134,18 @@ input {
 }
 
 .md-fences .code-tooltip {
-  background-color: #263238;
+    background-color: rgb(53, 95, 127);
+}
+
+#write .cm-s-inner .CodeMirror-selected,
+#write .cm-s-inner .CodeMirror-selectedtext {
+  background: #5b808d !important;
+}
+
+#typora-sidebar-resizer.dragging{
+    color: #6eace2;
+}
+
+#typora-sidebar-resizer{
+    left: calc(var(--sidebar-width) - 3px);
 }

--- a/blubook.css
+++ b/blubook.css
@@ -15,7 +15,7 @@
   --control-text-color: #ddd;
   --window-border: 1px solid #183055;
   --code-cursor: #f0f0f0;
-  --search-select-bg-color: rgba(248, 192, 116, .3);
+  --search-select-bg-color: rgba(248, 192, 116, 0.3);
   --search-select-text-color: rgb(59, 69, 78);
 }
 


### PR DESCRIPTION
**尝试完善下面几个点：**

文件访问面板、右键菜单偏移：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/100737632-61821180-340f-11eb-9ad7-077f2fc21333.png)

![image](https://user-images.githubusercontent.com/51501079/100737650-6646c580-340f-11eb-8061-de8b5bd63f6a.png)

</details>

解决：

```css
ol,
ul:not(#sidebar-files-menu,#context-menu) {/*不影响这两个部分*/
    padding-left: 2rem ;
    line-height: 1;
}
```

大纲黑色 hover 背景色及代码块语言设置区域，感觉有些暗，个人认为与周围颜色相近的话会不那么突兀，所以尝试做了修改：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/100737730-84142a80-340f-11eb-926f-09216f26a688.png)

![image](https://user-images.githubusercontent.com/51501079/100737746-89717500-340f-11eb-9cc5-5d687311f648.png)

</details>

更改：

```CSS
/*update：大纲 hover 背景色暗色改为浅色*/
#typora-sidebar #outline-content .outline-item:hover {
    background: var(--active-file-bg-color);
}
```

```CSS
/* update：代码块语言输入区域，暗色改为深蓝 */
.md-fences .code-tooltip {
    background-color: rgb(53, 95, 127);
}
```

感觉短代码背景色比较浅，不是很好与周围区分开：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/100737814-a3ab5300-340f-11eb-898b-0fb5ee750932.png)

</details>

所以试探着更改了颜色（相应地删除了原设置）：

```CSS
/* update: 更改短代码背景色（不影响搜索下的短代码） */
code:not(.md-search-expand) {
    /* rgb(233, 240, 254) 待选1*/
    /* rgb(245, 247, 249) 最初的颜色*/
    background: hsl(208, 84%, 88%) !important;
}
```

因为包含短代码的文字选中并搜索时，短代码颜色与周围颜色不协调：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/100737914-cb022000-340f-11eb-9f62-4075c9715b96.png)

</details>

所以上面设置短代码背景色时使用`:not(.md-search-expand)`将搜索下的短代码排除掉，并进一步地单独设置了选中搜索部分的代码背景色：

```CSS
/* 单独设置搜索下的短代码颜色 */
.md-search-expand code {
    background: hsla(0, 0%, 0%, 0) !important;
}
```

顺便将搜索部分的暗色改为橙色（个人认为这样更加美观）：

```CSS
    --search-select-bg-color:rgba(248,192,116,0.3);
    --search-select-text-color:rgb(59, 69, 78);
```

`短代码`、代码块中的中文字体不是很好看：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/100737995-ec630c00-340f-11eb-8f8d-56ff3fd0a97e.png)

</details>
  
所以参照[中文字体网页开发指南](http://www.ruanyifeng.com/blog/2014/07/chinese_fonts.html)将`font-family`完善为：

```CSS
code,
pre{
    ...
    font-family: 'Cascadia Code', Consolas, 'Noto Sans SC','Courier New',"微软雅黑",'Microsoft YaHei',"华文细黑",STXihei;
    ...
}
```

表格设置面板输入框及确认框偏离位置：

<details>
        <summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/100738098-13b9d900-3410-11eb-8942-ba7116c9872b.png)

</details>

更改：

```CSS
/*解决输入框问题*/
#write input:not(#md-grid-width):not(#md-grid-height){
    transform: translateY(-6.5px);
}
/*解决确认框问题*/
#write .popover.bottom.md-table-resize-popover{
    width: 140px;
}
/*顺便让输入框数字居中 */
#write .md-grid-board-wrap input{
    text-align: center !important;
}
```
  
代码块中选中文字的颜色与背景色很接近：

<details>
        <summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/100738185-351ac500-3410-11eb-92e6-f05ac630ad16.png)


</details>

更改：

```CSS
#write .cm-s-inner .CodeMirror-selected,
#write .cm-s-inner .CodeMirror-selectedtext {
    background: #5b808d !important;
}
```

往左伸缩大纲面板时指示线颜色与背景色很接近：

<details>
        <summary>Details</summary>


![dotedline](https://user-images.githubusercontent.com/51501079/100738341-6398a000-3410-11eb-82c7-f79ce3d93836.gif)


</details>

解决：

```CSS
/* 伸缩指示线颜色 */
#typora-sidebar-resizer.dragging{
    color: #6eace2;
}
```

然后发现伸缩线位置并不完全与大纲边界位置重合（偏右一点）导致容易失去伸缩线焦点，所以进行了如下调整：

```CSS
/* 更改指示线位置，使绳索指示线更顺手 */
#typora-sidebar-resizer{
    left: calc(var(--sidebar-width) 3px);
}
```