### PR TITLE
fix code in head; upgrade footnote and source mode

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -434,6 +434,14 @@ h6 {
   border-left: 2px solid var(--code-cursor);
 }
 
+#typora-source .CodeMirror-code pre{
+  font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
+}
+
+#typora-source .CodeMirror-code{
+  font-size: 1.1rem;
+}
+
 #write code,
 tt {
   margin: 0 2px;
@@ -446,8 +454,12 @@ tt {
   line-height: 1.8;
 }
 
+#write *[mdtype="heading"] code{
+  font-size: inherit!important;
+}
+
 #write .md-footnote {
-  color: var(--main-5);
+  color: rgb(56, 132, 254);
   background-color: var(--main-1);
 }
 
@@ -614,6 +626,14 @@ tt {
 
 #typora-sidebar #outline-content .outline-item:hover {
 	background: var(--active-file-bg-color);
+}
+
+#outline-content code{
+  margin-left:5px;
+  margin-right:5px;
+  padding:1px 2px;
+  vertical-align:baseline;
+  background-color: gray!important;
 }
 
 #typora-sidebar #ty-sidebar-footer #sidebar-files-menu .show+.menuitem-group-label.show {
@@ -1147,4 +1167,3 @@ input {
 #write .cm-s-inner .CodeMirror-selectedtext {
   background: #5b808d !important;
 }
-


### PR DESCRIPTION
**尝试完善下面几点**

**_源代码模式的字体和字号_**

字体设置为与预览模式下`<pre>`标签相同的字体，字号改设置为 1.1rem：

```CSS
#typora-source .CodeMirror-code pre{
  font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
}

#typora-source .CodeMirror-code{
  font-size: 1.1rem;
}
```

**_标题中的短代码_**

标题中的短代码显示不佳：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/101241359-445f8280-3730-11eb-9a4d-45e831ca91cb.png)

</details>

于是添加：

```CSS
#write *[mdtype="heading"] code{
  font-size: inherit!important;
}
```

**_脚注颜色_**

点击脚注可以跳转到脚注位置，个人认为显示为链接颜色（蓝色）更好：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/101241368-550ff880-3730-11eb-9b52-33b14d6cd7cd.png)

</details>

故脚注字体颜色改为与链接的颜色相同：

```CSS
#write .md-footnote {
  color: rgb(56, 132, 254);/*改为链接颜色*/
  background-color: var(--main-1);
}
```

**_大纲中的短代码_**

当标题中存在短代码时，大纲中的代码部分显示不佳：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/101241377-678a3200-3730-11eb-99b9-90ba4a788b69.png)

</details>

于是添加：

```CSS
#outline-content code{
  margin-left:5px;
  margin-right:5px;
  padding:1px 2px;
  vertical-align:baseline;
  background-color: gray!important;
}
```