### PR TITLE
fix font-size setting; upgrade source mode

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -159,7 +159,7 @@ h6.md-focus:before {
   left: -1.642857143rem;
   top: .357142857rem;
   float: left;
-  font-size: 9px;
+  font-size: 0.64rem;
   padding-left: 2px;
   padding-right: 2px;
   vertical-align: bottom;
@@ -177,6 +177,10 @@ body {
   -webkit-text-size-adjust: 100%
 }
 
+html{
+  font-size: 14px;
+}
+
 html,
 body {
   color: #242A31;
@@ -184,7 +188,6 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
-  font-size: 14px;
   background: #ffffff;
   box-sizing: border-box;
   line-height: 1rem;
@@ -293,7 +296,7 @@ pre.md-meta-block {
 
 /****** Global Text ******/
 p {
-  font-size: 16px;
+  font-size: 1.14rem;
   font-family: "Glow Sans SC", -apple-system, sans-serif;
   font-weight: 500;
   line-height: 1.6;
@@ -434,7 +437,8 @@ h6 {
   border-left: 2px solid var(--code-cursor);
 }
 
-#typora-source .CodeMirror-code pre{
+#typora-source .CodeMirror-code pre,
+.cm-s-typora-default .cm-overlay{
   font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
 }
 
@@ -463,8 +467,8 @@ tt {
   background-color: var(--main-1);
 }
 
-.cm-s-inner.CodeMirror,
-.cm-s-inner .CodeMirror-gutters {
+#write .cm-s-inner.CodeMirror,
+#write .cm-s-inner .CodeMirror-gutters {
   padding: 0.75rem 0.15rem 0.75rem 0.15rem;
   background-color: #183055 !important;
   color: #f8f8f2 !important;
@@ -816,7 +820,7 @@ blockquote::before {
   opacity: .2
 }
 
-.cm-s-inner .CodeMirror-vscrollbar {
+#write .cm-s-inner .CodeMirror-vscrollbar {
   display: none !important
 }
 
@@ -886,6 +890,57 @@ blockquote::before {
   color: #183055 !important;
 }
 
+/*
+
+    Name:       3024 day
+    Author:     Jan T. Sott (http://github.com/idleberg)
+
+    CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
+    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+
+*/
+
+.cm-s-typora-default.CodeMirror { background: #f7f7f7; color: #3a3432; }
+.cm-s-typora-default div.CodeMirror-selected { background: #d6d5d4; }
+
+.cm-s-typora-default .CodeMirror-line::selection, 
+.cm-s-typora-default .CodeMirror-line > span::selection, 
+.cm-s-typora-default .CodeMirror-line > span > span::selection { background: #d6d5d4; }
+.cm-s-typora-default .CodeMirror-line::-moz-selection, 
+.cm-s-typora-default .CodeMirror-line > span::-moz-selection, 
+.cm-s-typora-default .CodeMirror-line > span > span::selection { background: #d9d9d9; }
+
+.cm-s-typora-default .CodeMirror-gutters { background: #f7f7f7; border-right: 0px; }
+.cm-s-typora-default .CodeMirror-guttermarker { color: #db2d20; }
+.cm-s-typora-default .CodeMirror-guttermarker-subtle { color: #807d7c; }
+.cm-s-typora-default .CodeMirror-linenumber { color: #807d7c; }
+
+.cm-s-typora-default .CodeMirror-cursor { border-left: 1px solid #5c5855; }
+
+.cm-s-typora-default span.cm-comment { color: #cdab53; }
+.cm-s-typora-default span.cm-atom { color: #a16a94; }
+.cm-s-typora-default span.cm-number { color: #a16a94; }
+
+.cm-s-typora-default span.cm-property, 
+.cm-s-typora-default span.cm-attribute { color: #01a252; }
+.cm-s-typora-default span.cm-keyword { color: #db2d20; }
+/* .cm-s-typora-default span.cm-string { color: #fded02; } */
+
+.cm-s-typora-default span.cm-variable { color: #01a252; }
+.cm-s-typora-default span.cm-variable-2 { color: #01a0e4; }
+.cm-s-typora-default span.cm-def { color: #e8bbd0; }
+.cm-s-typora-default span.cm-bracket { color: #3a3432; }
+.cm-s-typora-default span.cm-tag { color: #db2d20; }
+.cm-s-typora-default span.cm-link { color: #a16a94; }
+/* .cm-s-typora-default span.cm-error { background: #db2d20; color: #5c5855; } */
+
+.cm-s-typora-default .CodeMirror-activeline-background { background: #e8f2ff; }
+.cm-s-typora-default .CodeMirror-matchingbracket { text-decoration: underline; color: #a16a94 !important; }
+
+.cm-s-typora-default .cm-comment{
+  font-family: 'Cascadia Code', Consolas, 'Glow Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
+}
+
 pre.CodeMirror-line {
   page-break-inside: avoid;
 }
@@ -910,8 +965,9 @@ code:not(.md-search-expand) {
 }
 
 code,
-pre {
-  font-size: 95% !important;
+pre,
+#write .md-mathblock-input {
+  font-size: 0.95rem !important;
   font-weight: normal;
   font-family: 'Cascadia Code', Consolas, 'Glow Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
   -webkit-font-smoothing: initial;
@@ -986,7 +1042,7 @@ input {
 }
 
 #write input:not(#md-grid-width):not(#md-grid-height) {
-  transform: translateY(-6.5px);
+  transform: translateY(-0.46rem);
 }
 
 #write .popover.bottom.md-table-resize-popover{
@@ -1034,128 +1090,128 @@ input {
 }
 
 /****** Code highlight ******/
-.cm-s-inner .CodeMirror-guttermarker,
-.cm-s-inner .CodeMirror-guttermarker-subtle,
-.cm-s-inner .CodeMirror-linenumber {
+#write .cm-s-inner .CodeMirror-guttermarker,
+#write .cm-s-inner .CodeMirror-guttermarker-subtle,
+#write .cm-s-inner .CodeMirror-linenumber {
   color: #596774;
 }
 
-.cm-s-inner .CodeMirror-cursor {
+#write .cm-s-inner .CodeMirror-cursor {
   border-left: 1px solid #f8f8f0;
 }
 
-.cm-s-inner div.CodeMirror-selected {
+#write .cm-s-inner div.CodeMirror-selected {
   background: rgba(255, 255, 255, 0.15);
 }
 
-.cm-s-inner.CodeMirror-focused div.CodeMirror-selected {
+#write .cm-s-inner.CodeMirror-focused div.CodeMirror-selected {
   background: rgba(255, 255, 255, 0.10);
 }
 
-.cm-s-inner .CodeMirror-line::selection,
-.cm-s-inner .CodeMirror-line>span::selection,
-.cm-s-inner .CodeMirror-line>span>span::selection {
+#write .cm-s-inner .CodeMirror-line::selection,
+#write .cm-s-inner .CodeMirror-line>span::selection,
+#write .cm-s-inner .CodeMirror-line>span>span::selection {
   background: rgba(255, 255, 255, 0.10);
 }
 
-.cm-s-inner .CodeMirror-line::-moz-selection,
-.cm-s-inner .CodeMirror-line>span::-moz-selection,
-.cm-s-inner .CodeMirror-line>span>span::-moz-selection {
+#write .cm-s-inner .CodeMirror-line::-moz-selection,
+#write .cm-s-inner .CodeMirror-line>span::-moz-selection,
+#write .cm-s-inner .CodeMirror-line>span>span::-moz-selection {
   background: rgba(255, 255, 255, 0.10);
 }
 
-.cm-s-inner .CodeMirror-activeline-background {
+#write .cm-s-inner .CodeMirror-activeline-background {
   background: rgba(0, 0, 0, 0);
 }
 
-.cm-s-inner .cm-keyword {
+#write .cm-s-inner .cm-keyword {
   color: rgba(199, 146, 234, 1);
 }
 
-.cm-s-inner .cm-operator {
+#write .cm-s-inner .cm-operator {
   color: rgba(233, 237, 237, 1);
 }
 
-.cm-s-inner .cm-variable-2 {
+#write .cm-s-inner .cm-variable-2 {
   color: #80CBC4;
 }
 
-.cm-s-inner .cm-variable-3 {
+#write .cm-s-inner .cm-variable-3 {
   color: #82B1FF;
 }
 
-.cm-s-inner .cm-builtin {
+#write .cm-s-inner .cm-builtin {
   color: #DECB6B;
 }
 
-.cm-s-inner .cm-atom {
+#write .cm-s-inner .cm-atom {
   color: #F77669;
 }
 
-.cm-s-inner .cm-number {
+#write .cm-s-inner .cm-number {
   color: #F77669;
 }
 
-.cm-s-inner .cm-def {
+#write .cm-s-inner .cm-def {
   color: rgba(233, 237, 237, 1);
 }
 
-.cm-s-inner .cm-string {
+#write .cm-s-inner .cm-string {
   color: #C3E88D;
 }
 
-.cm-s-inner .cm-string-2 {
+#write .cm-s-inner .cm-string-2 {
   color: #80CBC4;
 }
 
-.cm-s-inner .cm-comment {
+#write .cm-s-inner .cm-comment {
   color: #aebcc2;
 }
 
-.cm-s-inner .cm-variable {
+#write .cm-s-inner .cm-variable {
   color: #82B1FF;
 }
 
-.cm-s-inner .cm-tag {
+#write .cm-s-inner .cm-tag {
   color: #80CBC4;
 }
 
-.cm-s-inner .cm-meta {
+#write .cm-s-inner .cm-meta {
   color: #80CBC4;
 }
 
-.cm-s-inner .cm-attribute {
+#write .cm-s-inner .cm-attribute {
   color: #FFCB6B;
 }
 
-.cm-s-inner .cm-property {
+#write .cm-s-inner .cm-property {
   color: #80CBAE;
 }
 
-.cm-s-inner .cm-qualifier {
+#write .cm-s-inner .cm-qualifier {
   color: #DECB6B;
 }
 
-.cm-s-inner .cm-variable-3 {
+#write .cm-s-inner .cm-variable-3 {
   color: #DECB6B;
 }
 
-.cm-s-inner .cm-tag {
+#write .cm-s-inner .cm-tag {
   color: rgba(255, 83, 112, 1);
 }
 
-.cm-s-inner .cm-error {
+#write .cm-s-inner .cm-error {
   color: rgba(255, 255, 255, 1.0);
   background-color: #EC5F67;
 }
 
-.cm-s-inner .CodeMirror-matchingbracket {
+#write .cm-s-inner .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
 }
 
-.cm-s-inner .cm-header,
-.cm-s-inner.cm-header {
+#write .cm-s-inner .cm-header,
+#write .cm-s-inner.cm-header {
   color: #334EEA;
 }
 


### PR DESCRIPTION
**尝试解决或完善：**

***自定义字体大小效果不佳的问题（#16）***

首先，单独设置 `<html>` 的字体大小：

<details>
<summary>Details</summary>

```CSS
html{
  font-size: 14px;
}
```

</details>

然后，相关字号由 `px` 或 `%` 改为 `rem`。同时，因自定义字体大小后会造成待办偏离位置，所以修改待办偏移为`translateY(-0.46rem);`：

<details>
<summary>Details</summary>

```CSS
#write input:not(#md-grid-width):not(#md-grid-height) {
  transform: translateY(-0.46rem);/*修改为 rem*/
}
```

</details>

***源代码模式***

首先是完善源代码模式下的代码字体：

<details>
<summary>Details</summary>

```CSS
#typora-source .CodeMirror-code pre,
.cm-s-typora-default .cm-overlay{
  font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
}
```

</details>

然后发现源代码模式的类名、运算符等的颜色与背景色相近：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/101315865-61ae6100-3896-11eb-84f9-9ee02b9af61e.png)

</details>

这是因为预览模式下的代码样式影响了源代码模式下的代码样式，所以一方面通过添加 `#write` 将样式限制在预览模式下，另一方面从 [codemirror/theme/](https://codemirror.net/theme/) 获取 [3024\-day\.css](https://codemirror.net/theme/3024-day.css) 作为源代码模式下的高亮主题。

再就是源代码模式中也存在 `行内代码` 中文字体显示不佳的问题，所以添加了：

<details>
<summary>Details</summary>

```CSS
.cm-s-typora-default .cm-comment{
  font-family: 'Cascadia Code', Consolas, 'Glow Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
}
```

</details>

***公式块字体***

公式块中的字体应该与 `pre` 标签的字体一致：

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/51501079/101315908-71c64080-3896-11eb-810e-53a637108a9f.png)

</details>

所以将代码完善为：

<details>
<summary>Details</summary>

```CSS
code,
pre,
#write .md-mathblock-input {
  font-size: 0.95rem !important;
  font-weight: normal;
  font-family: 'Cascadia Code', Consolas, 'Glow Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
  -webkit-font-smoothing: initial;
  -moz-osx-font-smoothing: initial
}
```

</details>

