### PR TITLE
参造GitHub主题优化白边显示

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -34,10 +34,22 @@
 #write {
   position: static;
   width: 90%;
-  max-width: 1080px;
+  max-width: 860px;
   line-height: 1.6;
   transform: none;
   height: auto;
+}
+
+@media only screen and (min-width: 1400px) {
+	#write {
+		max-width: 1024px;
+	}
+}
+
+@media only screen and (min-width: 1800px) {
+	#write {
+		max-width: 1200px;
+	}
 }
 
 /****** #write h1-h6 ******/

--- a/blubook.css
+++ b/blubook.css
@@ -19,6 +19,11 @@
   --search-select-text-color: rgb(59, 69, 78);
 }
 
+.outline-item{
+  padding-bottom: 7px;
+  padding-top: 7px;
+}
+
 /*** Btn in search bar ***/
 #filesearch-case-option-btn,
 #filesearch-word-option-btn {
@@ -29,7 +34,7 @@
 #write {
   position: static;
   width: 90%;
-  max-width: 700px;
+  max-width: 1080px;
   line-height: 1.6;
   transform: none;
   height: auto;


### PR DESCRIPTION
  ### Change

#### 1. 大纲排列更利于观看

```css
.outline-item {
  padding-bottom: 7px;
  padding-top: 7px;
}
```

#### 2. 全屏下两白边变窄了

参造Github.css根据screen大小动态设置max-width:smile:

```css
/****** #write basic ******/
#write {
  position: static;
  width: 90%;
  max-width: 860px;
  line-height: 1.6;
  transform: none;
  height: auto;
}

@media only screen and (min-width: 1400px) {
	#write {
		max-width: 1024px;
	}
}

@media only screen and (min-width: 1800px) {
	#write {
		max-width: 1200px;
	}
}
```

