### PR TITLE
尝试完善快速打开面板中文本的颜色及源代码模式中的背景色

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -511,8 +511,9 @@ tt {
   font-size: 0.9rem;
 }
 
-/****** Sidebar ******/
-#typora-sidebar * {
+/****** Sidebar and Quick open******/
+#typora-sidebar *,
+#typora-quick-open{
   color: #f0f0f0;
 }
 
@@ -891,13 +892,10 @@ blockquote::before {
 }
 
 /*
-
     Name:       3024 day
     Author:     Jan T. Sott (http://github.com/idleberg)
-
     CodeMirror template by Jan T. Sott (https://github.com/idleberg/base16-codemirror)
     Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
-
 */
 
 .cm-s-typora-default.CodeMirror { background: #f7f7f7; color: #3a3432; }

--- a/blubook.css
+++ b/blubook.css
@@ -899,6 +899,7 @@ blockquote::before {
 */
 
 .cm-s-typora-default.CodeMirror { background: #f7f7f7; color: #3a3432; }
+.cm-s-typora-default.CodeMirror { background-color: #ffffff; }
 .cm-s-typora-default div.CodeMirror-selected { background: #d6d5d4; }
 
 .cm-s-typora-default .CodeMirror-line::selection, 
@@ -909,6 +910,7 @@ blockquote::before {
 .cm-s-typora-default .CodeMirror-line > span > span::selection { background: #d9d9d9; }
 
 .cm-s-typora-default .CodeMirror-gutters { background: #f7f7f7; border-right: 0px; }
+.cm-s-typora-default .CodeMirror-gutters { background: #ffffff; }
 .cm-s-typora-default .CodeMirror-guttermarker { color: #db2d20; }
 .cm-s-typora-default .CodeMirror-guttermarker-subtle { color: #807d7c; }
 .cm-s-typora-default .CodeMirror-linenumber { color: #807d7c; }


### PR DESCRIPTION
快速打开面板（我通过快捷键 Ctrl+P 打开）中的文字颜色与背景色很接近：

<details>
<summary>Details</summary>

![issue](https://user-images.githubusercontent.com/51501079/107147849-34139000-698b-11eb-93f2-fe2a035af961.png)

</details>

所以尝试对此进行完善。更改后：

<details>
<summary>Details</summary>

![fix](https://user-images.githubusercontent.com/51501079/107147874-586f6c80-698b-11eb-9012-f8805fe526cf.png)

</details>