### PR TITLE
Fix alignment

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -437,16 +437,19 @@ h6 {
   border-left: 2px solid var(--code-cursor);
 }
 
-#typora-source .CodeMirror-code pre,
 .cm-s-typora-default .cm-overlay{
   font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
+}
+
+/****** Fix source mode alignment issue ******/
+#typora-source .CodeMirror-code pre{
+  font-family: inherit;
 }
 
 #typora-source .CodeMirror-code{
   font-size: 1.1rem;
 }
 
-#write code,
 tt {
   margin: 0 2px;
   padding: 4px 6px;
@@ -455,6 +458,17 @@ tt {
   background: #f5f7f9;
   display: inline;
   vertical-align: bottom;
+  line-height: 1.8;
+}
+
+#write code{
+  margin: 0 2px;
+  padding: 3px 6px;
+  border-radius: 6px;
+  font-size: 1.1rem !important;/* Fix view mode alignment issue */
+  background: #f5f7f9;
+  display: inline;
+  vertical-align: initial;
   line-height: 1.8;
 }
 

--- a/blubook.css
+++ b/blubook.css
@@ -437,13 +437,9 @@ h6 {
   border-left: 2px solid var(--code-cursor);
 }
 
+#typora-source .CodeMirror-code pre,
 .cm-s-typora-default .cm-overlay{
   font-family: 'Cascadia Code', Consolas, 'Noto Sans SC', 'Courier New', "微软雅黑", 'Microsoft YaHei', "华文细黑", STXihei;
-}
-
-/****** Fix source mode alignment issue ******/
-#typora-source .CodeMirror-code pre{
-  font-family: inherit;
 }
 
 #typora-source .CodeMirror-code{


### PR DESCRIPTION
尝试修复 #45 中提到的对齐问题，解决方式是将 code 元素的字体大小由 0.92rem 改为 1.1rem，为使增大字体之后的 code 元素不显得太大，所以将上下内边距由 4px 改为 3px，同时，注意到更改后的 code 元素在段落中位置偏上，所以将 vertical-align 属性由 bottom 改为 initial 使其与段落文本横向对齐：

```diff
-#write code,
tt {
  ...
}

+#write code{
+  margin: 0 2px;
+  padding: 3px 6px;
+  border-radius: 6px;
+  font-size: 1.1rem !important;/* Fix view mode alignment issue */
+  background: #f5f7f9;
+  display: inline;
+  vertical-align: initial;
+  line-height: 1.8;
+}
```

对齐效果前后对比：

<details>
<summary>Details</summary>

![alignchange](https://user-images.githubusercontent.com/51501079/109751371-4c3c9f00-7c19-11eb-9d14-0ddac70262b1.png)

</details>

行内代码前后对比：

<details>
<summary>Details</summary>

![sizechange](https://user-images.githubusercontent.com/51501079/109751479-8443e200-7c19-11eb-8c0e-e44876ce74ce.png)

</details>


