### PR TITLE
Modify the distance between the code and the number of lines

### DIFF
--- a/blubook.css
+++ b/blubook.css
@@ -432,6 +432,7 @@ h6 {
 
 
 #write .CodeMirror-wrap .CodeMirror-code pre {
+  padding-left: 10px;
   line-height: 1.55rem;
 }
 

--- a/blubook.css
+++ b/blubook.css
@@ -432,7 +432,6 @@ h6 {
 
 
 #write .CodeMirror-wrap .CodeMirror-code pre {
-  padding-left: 30px;
   line-height: 1.55rem;
 }
 


### PR DESCRIPTION
The code in the block is too far away from the number of lines, I think：

<details>
<summary>Details</summary>

![demo](https://user-images.githubusercontent.com/51501079/115996640-a737b480-a612-11eb-8a8a-3e8cb91696f9.gif)

</details>